### PR TITLE
Potential fix for code scanning alert no. 15: Log Injection

### DIFF
--- a/authn-service/authn-service.py
+++ b/authn-service/authn-service.py
@@ -54,7 +54,8 @@ def get_user_profile(access_token):
 
 @app.route("/authenticate/<code>")
 def authenticate(code):
-    app.logger.debug("Received authentication request with code: %s", code)
+    sanitized_code = code.replace('\r\n', '').replace('\n', '')
+    app.logger.debug("Received authentication request with code: %s", sanitized_code)
     access_info, error = get_access_token(code)
 
     if error:


### PR DESCRIPTION
Potential fix for [https://github.com/Coveros-External/ghas-certification-bootcamp-emea-rdeveen/security/code-scanning/15](https://github.com/Coveros-External/ghas-certification-bootcamp-emea-rdeveen/security/code-scanning/15)

To fix the log injection issue, we need to sanitize the `code` parameter before logging it. This can be done by removing any newline characters from the `code` parameter. The best way to achieve this is to use the `replace` method to remove `\r\n` and `\n` characters from the `code` parameter before logging it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
